### PR TITLE
fix: include updater pubkey in desktop release configs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -243,6 +243,14 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Assert updater public key is configured
+        shell: bash
+        run: |
+          if [ -z "${TAURI_UPDATER_PUBKEY}" ]; then
+            echo "::error::TAURI_UPDATER_PUBKEY is required because generated grid configs enable updater artifacts."
+            exit 1
+          fi
+
       - name: Prepare desktop grid variant
         run: pnpm run desktop:grid:prepare:one
 

--- a/tools/tauri/grid.test.ts
+++ b/tools/tauri/grid.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import test from 'node:test';
 
@@ -6,11 +7,13 @@ import {
   GRID_BACKENDS,
   GRID_FRONTENDS,
   buildGeneratedTauriConfig,
+  getGeneratedConfigPath,
   getUpdaterManifestFileName,
   parseGridBackend,
   parseGridFrontend,
   resolveIdentifier,
   resolveProductName,
+  writeGeneratedTauriConfig,
 } from './grid.ts';
 import { TAURI_SRC_TAURI_ROOT, WORKSPACE_ROOT } from './common.ts';
 
@@ -28,14 +31,35 @@ test('grid selector parsing accepts supported frontend and backend ids', () => {
 });
 
 test('grid selector parsing rejects missing or unsupported ids', () => {
-  assert.throws(() => parseGridFrontend(undefined), /TAURI_GRID_FRONTEND is required/u);
-  assert.throws(() => parseGridFrontend(''), /TAURI_GRID_FRONTEND is required/u);
-  assert.throws(() => parseGridFrontend('  '), /TAURI_GRID_FRONTEND is required/u);
-  assert.throws(() => parseGridFrontend('svelte'), /Unsupported TAURI_GRID_FRONTEND/u);
-  assert.throws(() => parseGridBackend(undefined), /TAURI_GRID_BACKEND is required/u);
+  assert.throws(
+    () => parseGridFrontend(undefined),
+    /TAURI_GRID_FRONTEND is required/u,
+  );
+  assert.throws(
+    () => parseGridFrontend(''),
+    /TAURI_GRID_FRONTEND is required/u,
+  );
+  assert.throws(
+    () => parseGridFrontend('  '),
+    /TAURI_GRID_FRONTEND is required/u,
+  );
+  assert.throws(
+    () => parseGridFrontend('svelte'),
+    /Unsupported TAURI_GRID_FRONTEND/u,
+  );
+  assert.throws(
+    () => parseGridBackend(undefined),
+    /TAURI_GRID_BACKEND is required/u,
+  );
   assert.throws(() => parseGridBackend(''), /TAURI_GRID_BACKEND is required/u);
-  assert.throws(() => parseGridBackend('  '), /TAURI_GRID_BACKEND is required/u);
-  assert.throws(() => parseGridBackend('java'), /Unsupported TAURI_GRID_BACKEND/u);
+  assert.throws(
+    () => parseGridBackend('  '),
+    /TAURI_GRID_BACKEND is required/u,
+  );
+  assert.throws(
+    () => parseGridBackend('java'),
+    /Unsupported TAURI_GRID_BACKEND/u,
+  );
 });
 
 test('canonical ng-nest generated config preserves production identity and updater endpoint', () => {
@@ -47,7 +71,10 @@ test('canonical ng-nest generated config preserves production identity and updat
 
   assert.equal(config.productName, 'Desktop Tracker Suite');
   assert.equal(config.identifier, 'com.wodenwang820118.tracker.tauri');
-  assert.equal(config.$schema, '../../../node_modules/@tauri-apps/cli/config.schema.json');
+  assert.equal(
+    config.$schema,
+    '../../../node_modules/@tauri-apps/cli/config.schema.json',
+  );
   assert.equal(config.build.frontendDist, '../../../dist/ng-tracker/browser');
   assert.equal(config.bundle.createUpdaterArtifacts, true);
   assert.deepEqual(config.bundle.externalBin, ['binaries/nest-backend']);
@@ -66,6 +93,125 @@ test('canonical ng-nest generated config preserves production identity and updat
   ]);
 });
 
+test('generated config includes updater public key when provided', () => {
+  const config = buildGeneratedTauriConfig({
+    backend: 'express',
+    frontend: 'react',
+    updaterPubkey: '  public-key-content  ',
+    version: '1.4.2',
+  });
+
+  assert.equal(config.plugins.updater.pubkey, 'public-key-content');
+});
+
+test('generated config omits blank updater public key', () => {
+  const config = buildGeneratedTauriConfig({
+    backend: 'express',
+    frontend: 'react',
+    updaterPubkey: '  ',
+    version: '1.4.2',
+  });
+
+  assert.equal(Object.hasOwn(config.plugins.updater, 'pubkey'), false);
+});
+
+test('written generated config uses updater public key from environment', async () => {
+  const selection = { backend: 'express', frontend: 'vue' } as const;
+  const configPath = getGeneratedConfigPath(selection);
+  const previousPubkey = process.env.TAURI_UPDATER_PUBKEY;
+  let previousContents: string | undefined;
+
+  try {
+    previousContents = await readFile(configPath, 'utf8');
+  } catch (error) {
+    if ((error as { code?: string }).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  try {
+    process.env.TAURI_UPDATER_PUBKEY = '  env-public-key  ';
+    const withPubkey = await writeGeneratedTauriConfig({
+      ...selection,
+      version: '1.4.2',
+    });
+    assert.equal(withPubkey.config.plugins.updater.pubkey, 'env-public-key');
+    assert.equal(
+      (await readWrittenUpdater(configPath)).pubkey,
+      'env-public-key',
+    );
+
+    process.env.TAURI_UPDATER_PUBKEY = 'env-public-key';
+    const withExplicitPubkey = await writeGeneratedTauriConfig({
+      ...selection,
+      updaterPubkey: '  explicit-public-key  ',
+      version: '1.4.2',
+    });
+    assert.equal(
+      withExplicitPubkey.config.plugins.updater.pubkey,
+      'explicit-public-key',
+    );
+    assert.equal(
+      (await readWrittenUpdater(configPath)).pubkey,
+      'explicit-public-key',
+    );
+
+    process.env.TAURI_UPDATER_PUBKEY = '  ';
+    const withoutPubkey = await writeGeneratedTauriConfig({
+      ...selection,
+      version: '1.4.2',
+    });
+    assert.equal(
+      Object.hasOwn(withoutPubkey.config.plugins.updater, 'pubkey'),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(await readWrittenUpdater(configPath), 'pubkey'),
+      false,
+    );
+
+    process.env.TAURI_UPDATER_PUBKEY = '';
+    const withoutEmptyPubkey = await writeGeneratedTauriConfig({
+      ...selection,
+      version: '1.4.2',
+    });
+    assert.equal(
+      Object.hasOwn(withoutEmptyPubkey.config.plugins.updater, 'pubkey'),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(await readWrittenUpdater(configPath), 'pubkey'),
+      false,
+    );
+
+    delete process.env.TAURI_UPDATER_PUBKEY;
+    const withoutEnvPubkey = await writeGeneratedTauriConfig({
+      ...selection,
+      version: '1.4.2',
+    });
+    assert.equal(
+      Object.hasOwn(withoutEnvPubkey.config.plugins.updater, 'pubkey'),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(await readWrittenUpdater(configPath), 'pubkey'),
+      false,
+    );
+  } finally {
+    if (previousPubkey === undefined) {
+      delete process.env.TAURI_UPDATER_PUBKEY;
+    } else {
+      process.env.TAURI_UPDATER_PUBKEY = previousPubkey;
+    }
+
+    if (previousContents === undefined) {
+      await rm(configPath, { force: true });
+    } else {
+      await writeFile(configPath, previousContents);
+    }
+  }
+});
+
 test('ng-spring-native preserves the legacy PoC identity and adds variant updater behavior', () => {
   const config = buildGeneratedTauriConfig({
     backend: 'spring-native',
@@ -74,13 +220,20 @@ test('ng-spring-native preserves the legacy PoC identity and adds variant update
   });
 
   assert.equal(config.productName, 'Desktop Tracker Suite Spring Native PoC');
-  assert.equal(config.identifier, 'com.wodenwang820118.tracker.tauri.springnative');
-  assert.equal(config.$schema, '../../../node_modules/@tauri-apps/cli/config.schema.json');
+  assert.equal(
+    config.identifier,
+    'com.wodenwang820118.tracker.tauri.springnative',
+  );
+  assert.equal(
+    config.$schema,
+    '../../../node_modules/@tauri-apps/cli/config.schema.json',
+  );
   assert.equal(config.build.frontendDist, '../../../dist/ng-tracker/browser');
   assert.equal(config.bundle.createUpdaterArtifacts, true);
   assert.deepEqual(config.bundle.externalBin, ['binaries/spring-backend']);
   assert.deepEqual(config.bundle.resources, {
-    '../../../dist/tauri-shell-spring-native/resources/spring-native': 'spring-native',
+    '../../../dist/tauri-shell-spring-native/resources/spring-native':
+      'spring-native',
     '../../../dist/tauri-shell-spring-native/resources/metadata': 'metadata',
   });
   assert.deepEqual(config.plugins.updater.endpoints, [
@@ -101,13 +254,15 @@ test('generated grid configs cover all frontend dist paths and backend runtime r
   } as const;
   const expectedResources = {
     express: {
-      '../../../dist/tauri-shell-express-sidecar/resources/metadata': 'metadata',
+      '../../../dist/tauri-shell-express-sidecar/resources/metadata':
+        'metadata',
     },
     nest: {
       '../../../dist/tauri-shell-nest-sidecar/resources/metadata': 'metadata',
     },
     'spring-native': {
-      '../../../dist/tauri-shell-spring-native/resources/spring-native': 'spring-native',
+      '../../../dist/tauri-shell-spring-native/resources/spring-native':
+        'spring-native',
       '../../../dist/tauri-shell-spring-native/resources/metadata': 'metadata',
     },
   } as const;
@@ -119,9 +274,16 @@ test('generated grid configs cover all frontend dist paths and backend runtime r
 
   for (const frontend of GRID_FRONTENDS) {
     for (const backend of GRID_BACKENDS) {
-      const config = buildGeneratedTauriConfig({ backend, frontend, version: '1.4.2' });
+      const config = buildGeneratedTauriConfig({
+        backend,
+        frontend,
+        version: '1.4.2',
+      });
 
-      assert.equal(config.$schema, '../../../node_modules/@tauri-apps/cli/config.schema.json');
+      assert.equal(
+        config.$schema,
+        '../../../node_modules/@tauri-apps/cli/config.schema.json',
+      );
       assert.equal(config.build.frontendDist, expectedFrontendDist[frontend]);
       assert.equal(
         resolve(TAURI_SRC_TAURI_ROOT, config.build.frontendDist),
@@ -132,9 +294,15 @@ test('generated grid configs cover all frontend dist paths and backend runtime r
       assert.deepEqual(config.bundle.externalBin, expectedExternalBin[backend]);
       assert.deepEqual(config.bundle.resources, expectedResources[backend]);
       for (const resourcePath of Object.keys(config.bundle.resources)) {
-        const resolvedResourcePath = resolve(TAURI_SRC_TAURI_ROOT, resourcePath);
+        const resolvedResourcePath = resolve(
+          TAURI_SRC_TAURI_ROOT,
+          resourcePath,
+        );
         assert.equal(isWorkspacePath(resolvedResourcePath), true);
-        assert.equal(relative(WORKSPACE_ROOT, resolvedResourcePath).split(/[\\/]/u)[0], 'dist');
+        assert.equal(
+          relative(WORKSPACE_ROOT, resolvedResourcePath).split(/[\\/]/u)[0],
+          'dist',
+        );
       }
       assert.equal(
         config.plugins.updater.endpoints[0],
@@ -144,6 +312,7 @@ test('generated grid configs cover all frontend dist paths and backend runtime r
             : getUpdaterManifestFileName({ backend, frontend })
         }`,
       );
+      assert.equal(Object.hasOwn(config.plugins.updater, 'pubkey'), false);
     }
   }
 });
@@ -165,5 +334,19 @@ test('non-canonical identifiers and product names are stable', () => {
 
 function isWorkspacePath(path: string): boolean {
   const relativePath = relative(WORKSPACE_ROOT, path);
-  return relativePath !== '..' && !relativePath.startsWith(`..\\`) && !relativePath.startsWith('../');
+  return (
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..\\`) &&
+    !relativePath.startsWith('../')
+  );
+}
+
+async function readWrittenUpdater(
+  configPath: string,
+): Promise<{ pubkey?: string }> {
+  const writtenConfig = JSON.parse(await readFile(configPath, 'utf8')) as {
+    plugins?: { updater?: { pubkey?: string } };
+  };
+  assert.ok(writtenConfig.plugins?.updater, 'Expected plugins.updater');
+  return writtenConfig.plugins.updater;
 }

--- a/tools/tauri/grid.ts
+++ b/tools/tauri/grid.ts
@@ -14,7 +14,11 @@ export type GridFrontend = (typeof GRID_FRONTENDS)[number];
 export const GRID_BACKENDS = ['nest', 'express', 'spring-native'] as const;
 export type GridBackend = (typeof GRID_BACKENDS)[number];
 
-export const GRID_DESKTOP_TARGETS = ['windows-x64', 'linux-x64', 'darwin-arm64'] as const;
+export const GRID_DESKTOP_TARGETS = [
+  'windows-x64',
+  'linux-x64',
+  'darwin-arm64',
+] as const;
 export type GridDesktopTarget = (typeof GRID_DESKTOP_TARGETS)[number];
 
 export const GENERATED_GRID_CONFIG_DIR_NAME = 'generated-grid-configs';
@@ -94,6 +98,7 @@ export type TauriConfig = {
   plugins: {
     updater: {
       endpoints: string[];
+      pubkey?: string;
       windows: {
         installMode: 'passive';
       };
@@ -105,7 +110,14 @@ export type TauriConfig = {
 
 const FRONTEND_DEFINITIONS: Record<GridFrontend, GridFrontendDefinition> = {
   ng: {
-    buildArgs: ['exec', 'nx', 'build', 'ng-tracker', '--configuration', 'tauri'],
+    buildArgs: [
+      'exec',
+      'nx',
+      'build',
+      'ng-tracker',
+      '--configuration',
+      'tauri',
+    ],
     distPathFromGeneratedConfig: `${GENERATED_CONFIG_ROOT_PREFIX}/dist/ng-tracker/browser`,
     label: 'Angular',
   },
@@ -123,10 +135,20 @@ const FRONTEND_DEFINITIONS: Record<GridFrontend, GridFrontendDefinition> = {
 
 const BACKEND_DEFINITIONS: Record<GridBackend, GridBackendDefinition> = {
   express: {
-    buildArgs: ['exec', 'nx', 'build', 'express-backend', '--configuration', 'production'],
+    buildArgs: [
+      'exec',
+      'nx',
+      'build',
+      'express-backend',
+      '--configuration',
+      'production',
+    ],
     externalBin: ['binaries/express-backend'],
     label: 'Express',
-    materializeArgs: ['tools/tauri/materialize-node-sidecar-runtime.ts', 'express'],
+    materializeArgs: [
+      'tools/tauri/materialize-node-sidecar-runtime.ts',
+      'express',
+    ],
     resources: {
       [`${GENERATED_CONFIG_ROOT_PREFIX}/dist/tauri-shell-express-sidecar/resources/metadata`]:
         'metadata',
@@ -134,10 +156,20 @@ const BACKEND_DEFINITIONS: Record<GridBackend, GridBackendDefinition> = {
     smokeArgs: ['tools/tauri/smoke-node-sidecar-runtime.ts', 'express'],
   },
   nest: {
-    buildArgs: ['exec', 'nx', 'build', 'nest-backend', '--configuration', 'production'],
+    buildArgs: [
+      'exec',
+      'nx',
+      'build',
+      'nest-backend',
+      '--configuration',
+      'production',
+    ],
     externalBin: ['binaries/nest-backend'],
     label: 'Nest',
-    materializeArgs: ['tools/tauri/materialize-node-sidecar-runtime.ts', 'nest'],
+    materializeArgs: [
+      'tools/tauri/materialize-node-sidecar-runtime.ts',
+      'nest',
+    ],
     resources: {
       [`${GENERATED_CONFIG_ROOT_PREFIX}/dist/tauri-shell-nest-sidecar/resources/metadata`]:
         'metadata',
@@ -159,11 +191,15 @@ const BACKEND_DEFINITIONS: Record<GridBackend, GridBackendDefinition> = {
   },
 };
 
-export function getFrontendDefinition(frontend: GridFrontend): GridFrontendDefinition {
+export function getFrontendDefinition(
+  frontend: GridFrontend,
+): GridFrontendDefinition {
   return FRONTEND_DEFINITIONS[frontend];
 }
 
-export function getBackendDefinition(backend: GridBackend): GridBackendDefinition {
+export function getBackendDefinition(
+  backend: GridBackend,
+): GridBackendDefinition {
   return BACKEND_DEFINITIONS[backend];
 }
 
@@ -200,16 +236,25 @@ export function resolveGridSelectionFromEnv(
   });
 }
 
-export function getGridVariantKey({ backend, frontend }: GridSelection): string {
+export function getGridVariantKey({
+  backend,
+  frontend,
+}: GridSelection): string {
   return `${frontend}-${backend}`;
 }
 
-export function getGeneratedConfigProjectPath(selection: GridSelection): string {
+export function getGeneratedConfigProjectPath(
+  selection: GridSelection,
+): string {
   return `src-tauri/${GENERATED_GRID_CONFIG_DIR_NAME}/${getGridVariantKey(selection)}.conf.json`;
 }
 
 export function getGeneratedConfigPath(selection: GridSelection): string {
-  return join(TAURI_SRC_TAURI_ROOT, GENERATED_GRID_CONFIG_DIR_NAME, `${getGridVariantKey(selection)}.conf.json`);
+  return join(
+    TAURI_SRC_TAURI_ROOT,
+    GENERATED_GRID_CONFIG_DIR_NAME,
+    `${getGridVariantKey(selection)}.conf.json`,
+  );
 }
 
 export function getUpdaterManifestFileName(selection: GridSelection): string {
@@ -227,6 +272,7 @@ export function isCanonicalGridSelection(selection: GridSelection): boolean {
 export function buildGeneratedTauriConfig(input: {
   backend: GridBackend;
   frontend: GridFrontend;
+  updaterPubkey?: string;
   version: string;
 }): TauriConfig {
   const selection = {
@@ -239,6 +285,7 @@ export function buildGeneratedTauriConfig(input: {
   const manifestFileName = isCanonicalGridSelection(selection)
     ? getCanonicalUpdaterManifestFileName()
     : getUpdaterManifestFileName(selection);
+  const updaterPubkey = input.updaterPubkey?.trim();
 
   return {
     $schema: `${GENERATED_CONFIG_ROOT_PREFIX}/node_modules/@tauri-apps/cli/config.schema.json`,
@@ -284,6 +331,7 @@ export function buildGeneratedTauriConfig(input: {
     plugins: {
       updater: {
         endpoints: [`${REPOSITORY_RELEASE_DOWNLOAD_BASE}/${manifestFileName}`],
+        ...(updaterPubkey ? { pubkey: updaterPubkey } : {}),
         windows: {
           installMode: 'passive',
         },
@@ -295,13 +343,17 @@ export function buildGeneratedTauriConfig(input: {
 export async function writeGeneratedTauriConfig(input: {
   backend: GridBackend;
   frontend: GridFrontend;
+  updaterPubkey?: string;
   version: string;
 }): Promise<GeneratedGridConfigResult> {
   const selection = {
     backend: input.backend,
     frontend: input.frontend,
   };
-  const config = buildGeneratedTauriConfig(input);
+  const config = buildGeneratedTauriConfig({
+    ...input,
+    updaterPubkey: input.updaterPubkey ?? process.env.TAURI_UPDATER_PUBKEY,
+  });
   const configPath = getGeneratedConfigPath(selection);
   await ensureDir(GENERATED_GRID_CONFIG_DIR);
   await writeJson(configPath, config);
@@ -314,7 +366,9 @@ export async function writeGeneratedTauriConfig(input: {
 }
 
 export async function readWorkspaceVersion(): Promise<string> {
-  const packageJson = await readJson<{ version?: string }>(join(WORKSPACE_ROOT, 'package.json'));
+  const packageJson = await readJson<{ version?: string }>(
+    join(WORKSPACE_ROOT, 'package.json'),
+  );
   const version = packageJson.version?.trim();
   if (!version) {
     throw new Error('The root package.json is missing a version field.');
@@ -358,14 +412,18 @@ function parseGridValue<const TValue extends readonly string[]>(
 ): TValue[number] {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) {
-    throw new Error(`${envName} is required. Expected one of: ${allowedValues.join(', ')}.`);
+    throw new Error(
+      `${envName} is required. Expected one of: ${allowedValues.join(', ')}.`,
+    );
   }
 
   if ((allowedValues as readonly string[]).includes(normalized)) {
     return normalized as TValue[number];
   }
 
-  throw new Error(`Unsupported ${envName} "${value}". Expected one of: ${allowedValues.join(', ')}.`);
+  throw new Error(
+    `Unsupported ${envName} "${value}". Expected one of: ${allowedValues.join(', ')}.`,
+  );
 }
 
 function normalizeBackendForIdentifier(backend: GridBackend): string {
@@ -373,5 +431,8 @@ function normalizeBackendForIdentifier(backend: GridBackend): string {
 }
 
 function normalizePathForTauriProject(path: string): string {
-  return relative(join(WORKSPACE_ROOT, 'apps', 'tauri-shell'), path).replaceAll('\\', '/');
+  return relative(join(WORKSPACE_ROOT, 'apps', 'tauri-shell'), path).replaceAll(
+    '\\',
+    '/',
+  );
 }


### PR DESCRIPTION
## Summary

- Add a release workflow preflight that fails clearly when `TAURI_UPDATER_PUBKEY` is not configured.
- Pass `TAURI_UPDATER_PUBKEY` into generated Tauri grid configs as `plugins.updater.pubkey`.
- Add regression coverage for generated updater pubkey handling, including the CI env path and on-disk generated JSON.

## Root Cause

The Desktop Release workflow did trigger on `main`, but Tauri packaging failed before publishing because generated grid configs enabled updater artifacts without the required Tauri v2 updater `pubkey` field.

## Validation

- `pnpm run desktop:test:tooling` passed, 127 tests.
- `pnpm exec prettier --check tools/tauri/grid.ts tools/tauri/grid.test.ts .github/workflows/desktop-release.yml` passed.
- `git diff --check` passed with only line-ending warnings.
- `actionlint .github/workflows/desktop-release.yml` passed.
- Plan, implementation, and test review checkpoints had no blocking findings.