### PR TITLE
[codex] Limit desktop release to Windows and Linux

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -155,9 +155,6 @@ jobs:
           - runner: ubuntu-22.04
             desktop_target: linux-x64
             rust_target: x86_64-unknown-linux-gnu
-          - runner: macos-latest
-            desktop_target: darwin-arm64
-            rust_target: aarch64-apple-darwin
         frontend:
           - ng
           - react
@@ -177,12 +174,6 @@ jobs:
       TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
       WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
 
@@ -331,12 +322,6 @@ jobs:
           TAURI_UPDATER_PUBKEY: ${{ env.TAURI_UPDATER_PUBKEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ env.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ env.APPLE_ID }}
-          APPLE_PASSWORD: ${{ env.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ env.APPLE_TEAM_ID }}
         with:
           projectPath: apps/tauri-shell
           tagName: ${{ env.RELEASE_TAG }}

--- a/tools/tauri/generate-updater-manifests.test.ts
+++ b/tools/tauri/generate-updater-manifests.test.ts
@@ -23,18 +23,27 @@ import {
 import { WORKSPACE_ROOT } from './common.ts';
 
 test('parseReleaseArtifact extracts variant and desktop target from asset names', () => {
-  const darwinSignature = parseReleaseArtifact(
-    join(
-      'release',
-      'desktop-tracker-suite-react-spring-native-1.4.2-darwin-aarch64.app.tar.gz.sig',
+  assert.equal(
+    parseReleaseArtifact(
+      join(
+        'release',
+        'desktop-tracker-suite-react-spring-native-1.4.2-darwin-aarch64.app.tar.gz.sig',
+      ),
     ),
+    null,
   );
-
-  assert.ok(darwinSignature);
-  assert.equal(darwinSignature.selection.frontend, 'react');
-  assert.equal(darwinSignature.selection.backend, 'spring-native');
-  assert.equal(darwinSignature.desktopTarget, 'darwin-arm64');
-  assert.equal(darwinSignature.isSignature, true);
+  assert.equal(
+    parseReleaseArtifact(
+      join('release', 'desktop-tracker-suite-ng-nest-1.4.2-darwin-aarch64.app.tar.gz'),
+    ),
+    null,
+  );
+  assert.equal(
+    parseReleaseArtifact(
+      join('release', 'desktop-tracker-suite-ng-nest-1.4.2-darwin-x64.app.tar.gz'),
+    ),
+    null,
+  );
 
   const windowsAsset = parseReleaseArtifact(
     join('release', 'desktop-tracker-suite-ng-nest-1.4.2-windows-x64-setup.exe'),
@@ -73,6 +82,12 @@ test('selectUpdaterArtifactPair prefers the highest priority Windows signature p
 
 test('buildUpdaterManifestContents emits all variant manifests and canonical alias content', async () => {
   const releaseDir = await createCompleteReleaseArtifactTree();
+  // The unsupported darwin pair must be ignored by the react-express manifest below.
+  await writeUnsupportedDarwinArtifactPair({
+    backend: 'express',
+    frontend: 'react',
+    root: releaseDir,
+  });
   const manifests = await buildUpdaterManifestContents({
     now: new Date('2026-04-27T00:00:00.000Z'),
     releaseDir,
@@ -96,7 +111,6 @@ test('buildUpdaterManifestContents emits all variant manifests and canonical ali
   assert.equal(reactExpress.version, '1.4.2');
   assert.equal(reactExpress.pub_date, '2026-04-27T00:00:00.000Z');
   assert.deepEqual(Object.keys(reactExpress.platforms).sort(), [
-    'darwin-aarch64',
     'linux-x86_64',
     'windows-x86_64',
   ]);
@@ -112,6 +126,11 @@ test('buildUpdaterManifestContents emits all variant manifests and canonical ali
 
 test('generateUpdaterManifestFiles copies latest-ng-nest.json byte-for-byte to latest.json', async () => {
   const releaseDir = await createCompleteReleaseArtifactTree();
+  await writeUnsupportedDarwinArtifactPair({
+    backend: 'nest',
+    frontend: 'ng',
+    root: releaseDir,
+  });
   const outputRoot = join(WORKSPACE_ROOT, 'tmp');
   await mkdir(outputRoot, { recursive: true });
   const outputDir = join(await mkdtemp(join(outputRoot, 'tauri-updater-output-')), 'manifests');
@@ -148,6 +167,14 @@ test('generateUpdaterManifestFiles copies latest-ng-nest.json byte-for-byte to l
     join(outputDir, getCanonicalUpdaterManifestFileName()),
   );
   assert.deepEqual(canonicalAlias, canonicalVariant);
+
+  const canonicalManifest = JSON.parse(canonicalVariant.toString('utf8')) as {
+    platforms: Record<string, { signature: string; url: string }>;
+  };
+  assert.deepEqual(Object.keys(canonicalManifest.platforms).sort(), [
+    'linux-x86_64',
+    'windows-x86_64',
+  ]);
 });
 
 test('buildUpdaterManifestContents fails when a required platform artifact is missing', async () => {
@@ -162,6 +189,7 @@ test('buildUpdaterManifestContents fails when a required platform artifact is mi
   await assert.rejects(
     () =>
       buildUpdaterManifestContents({
+        now: new Date('2026-04-27T00:00:00.000Z'),
         releaseDir,
         releaseTag: 'v1.4.2',
         version: '1.4.2',
@@ -219,6 +247,22 @@ async function writeArtifactPair(input: {
   );
 }
 
+async function writeUnsupportedDarwinArtifactPair(input: {
+  backend: GridBackend;
+  frontend: GridFrontend;
+  root: string;
+}) {
+  const variantDir = join(input.root, `${input.frontend}-${input.backend}`);
+  await mkdir(variantDir, { recursive: true });
+  const assetName = `desktop-tracker-suite-${input.frontend}-${input.backend}-1.4.2-darwin-aarch64.app.tar.gz`;
+  await writeFile(join(variantDir, assetName), `${assetName}\n`, 'utf8');
+  await writeFile(
+    join(variantDir, `${assetName}.sig`),
+    `signature ${input.frontend}-${input.backend} unsupported-darwin`,
+    'utf8',
+  );
+}
+
 function buildSampleAssetName(input: {
   backend: GridBackend;
   desktopTarget: GridDesktopTarget;
@@ -233,7 +277,8 @@ function buildSampleAssetName(input: {
     return `${prefix}-linux-x64.AppImage.tar.gz`;
   }
 
-  return `${prefix}-darwin-aarch64.app.tar.gz`;
+  const exhaustive: never = input.desktopTarget;
+  throw new Error(`Unsupported sample desktop target: ${exhaustive}`);
 }
 
 function releaseArtifact(fileName: string, isSignature = false) {

--- a/tools/tauri/generate-updater-manifests.ts
+++ b/tools/tauri/generate-updater-manifests.ts
@@ -51,16 +51,11 @@ export type GenerateUpdaterManifestsInput = {
 const RELEASE_DOWNLOAD_BASE = 'https://github.com/WodenWang820118/nx-electron/releases/download';
 
 const TARGET_PLATFORM_KEYS: Record<GridDesktopTarget, string> = {
-  'darwin-arm64': 'darwin-aarch64',
   'linux-x64': 'linux-x86_64',
   'windows-x64': 'windows-x86_64',
 };
 
 const TARGET_NAME_PARTS: Record<GridDesktopTarget, { arch: string[]; platform: string[] }> = {
-  'darwin-arm64': {
-    arch: ['aarch64', 'arm64'],
-    platform: ['darwin', 'macos'],
-  },
   'linux-x64': {
     arch: ['x64', 'x86_64', 'amd64'],
     platform: ['linux'],
@@ -273,11 +268,6 @@ function signaturePriority(fileName: string, desktopTarget: GridDesktopTarget): 
   if (desktopTarget === 'linux-x64') {
     if (fileName.endsWith('.AppImage.tar.gz.sig')) return 100;
     if (fileName.endsWith('.AppImage.sig')) return 90;
-  }
-
-  if (desktopTarget === 'darwin-arm64') {
-    if (fileName.endsWith('.app.tar.gz.sig')) return 100;
-    if (fileName.endsWith('.dmg.sig')) return 80;
   }
 
   return 0;

--- a/tools/tauri/grid.ts
+++ b/tools/tauri/grid.ts
@@ -17,7 +17,6 @@ export type GridBackend = (typeof GRID_BACKENDS)[number];
 export const GRID_DESKTOP_TARGETS = [
   'windows-x64',
   'linux-x64',
-  'darwin-arm64',
 ] as const;
 export type GridDesktopTarget = (typeof GRID_DESKTOP_TARGETS)[number];
 


### PR DESCRIPTION
## Summary

- Remove the macOS target from the Desktop Release package matrix so release publishing no longer requires Apple Developer signing/notarization.
- Narrow updater release targets to Windows/Linux and remove darwin manifest mapping/signature handling.
- Update updater manifest tests so darwin artifacts are ignored and written manifests contain only Windows/Linux platform keys.

## Why

Apple Developer signing/notarization is unavailable for this project right now, so the macOS release jobs fail before the desktop release can publish. This keeps the release path usable for Windows and Linux while preserving updater signing.

## Verification

- Plan review passed.
- Test review passed.
- Implementation review passed.
- `pnpm run desktop:test:tooling` passed: 127 tests.
- `git diff --check` passed, with only local CRLF warnings.
- Confirmed `.github/workflows/desktop-release.yml` no longer contains `macos-latest`, `darwin-arm64`, or Apple signing env mappings.

## Residual Risk

Existing macOS arm64 installs will not receive `darwin-aarch64` updater entries until macOS release signing is restored. Restoring macOS releases later requires adding the workflow matrix target and manifest target mappings back together.