### PR TITLE
[codex] Fix desktop release repo rename

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -331,12 +331,9 @@ jobs:
           releaseDraft: true
           prerelease: false
           generateReleaseNotes: true
-          uploadUpdaterJson: false
+          includeUpdaterJson: false
           updaterJsonPreferNsis: true
-          uploadWorkflowArtifacts: true
-          uploadUpdaterSignatures: true
-          workflowArtifactNamePattern: desktop-tracker-suite-${{ matrix.frontend }}-${{ matrix.backend }}-[version]-[platform]-[arch]-[bundle]
-          releaseAssetNamePattern: desktop-tracker-suite-${{ matrix.frontend }}-${{ matrix.backend }}-[version]-[platform]-[arch][setup][ext]
+          assetNamePattern: desktop-tracker-suite-${{ matrix.frontend }}-${{ matrix.backend }}-[version]-[platform]-[arch][setup][ext]
           # The release is published only after all package jobs finish and aggregate-updater-manifests uploads latest*.json files.
           args: --config ${{ env.TAURI_GRID_CONFIG }} --target ${{ matrix.target.rust_target }}
 

--- a/apps/tauri-shell/src-tauri/tauri.conf.json
+++ b/apps/tauri-shell/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/WodenWang820118/nx-electron/releases/latest/download/latest.json"
+        "https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/apps/tauri-shell/src-tauri/tauri.release.conf.json
+++ b/apps/tauri-shell/src-tauri/tauri.release.conf.json
@@ -44,7 +44,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/WodenWang820118/nx-electron/releases/latest/download/latest.json"
+        "https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/tools/tauri/generate-updater-manifests.test.ts
+++ b/tools/tauri/generate-updater-manifests.test.ts
@@ -116,7 +116,7 @@ test('buildUpdaterManifestContents emits all variant manifests and canonical ali
   ]);
   assert.equal(
     reactExpress.platforms['windows-x86_64'].url,
-    'https://github.com/WodenWang820118/nx-electron/releases/download/v1.4.2/desktop-tracker-suite-react-express-1.4.2-windows-x64-setup.exe',
+    'https://github.com/WodenWang820118/desktop-tracker-suite/releases/download/v1.4.2/desktop-tracker-suite-react-express-1.4.2-windows-x64-setup.exe',
   );
   assert.equal(
     reactExpress.platforms['linux-x86_64'].signature,

--- a/tools/tauri/generate-updater-manifests.ts
+++ b/tools/tauri/generate-updater-manifests.ts
@@ -48,7 +48,8 @@ export type GenerateUpdaterManifestsInput = {
   version?: string;
 };
 
-const RELEASE_DOWNLOAD_BASE = 'https://github.com/WodenWang820118/nx-electron/releases/download';
+const RELEASE_DOWNLOAD_BASE =
+  'https://github.com/WodenWang820118/desktop-tracker-suite/releases/download';
 
 const TARGET_PLATFORM_KEYS: Record<GridDesktopTarget, string> = {
   'linux-x64': 'linux-x86_64',

--- a/tools/tauri/grid.test.ts
+++ b/tools/tauri/grid.test.ts
@@ -18,7 +18,7 @@ import {
 import { TAURI_SRC_TAURI_ROOT, WORKSPACE_ROOT } from './common.ts';
 
 const RELEASE_DOWNLOAD_BASE =
-  'https://github.com/WodenWang820118/nx-electron/releases/latest/download';
+  'https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download';
 
 test('grid selector parsing accepts supported frontend and backend ids', () => {
   assert.equal(parseGridFrontend('ng'), 'ng');
@@ -89,7 +89,7 @@ test('canonical ng-nest generated config preserves production identity and updat
     'icons/icon.ico',
   ]);
   assert.deepEqual(config.plugins.updater.endpoints, [
-    'https://github.com/WodenWang820118/nx-electron/releases/latest/download/latest.json',
+    'https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download/latest.json',
   ]);
 });
 
@@ -237,7 +237,7 @@ test('ng-spring-native preserves the legacy PoC identity and adds variant update
     '../../../dist/tauri-shell-spring-native/resources/metadata': 'metadata',
   });
   assert.deepEqual(config.plugins.updater.endpoints, [
-    'https://github.com/WodenWang820118/nx-electron/releases/latest/download/latest-ng-spring-native.json',
+    'https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download/latest-ng-spring-native.json',
   ]);
 });
 

--- a/tools/tauri/grid.ts
+++ b/tools/tauri/grid.ts
@@ -28,7 +28,7 @@ export const GENERATED_GRID_CONFIG_DIR = join(
 
 const PRODUCT_NAME = 'Desktop Tracker Suite';
 const REPOSITORY_RELEASE_DOWNLOAD_BASE =
-  'https://github.com/WodenWang820118/nx-electron/releases/latest/download';
+  'https://github.com/WodenWang820118/desktop-tracker-suite/releases/latest/download';
 const GENERATED_CONFIG_ROOT_PREFIX = '../../..';
 const DEFAULT_DEV_URL =
   'http://localhost:4200/?taskApiUrl=http%3A%2F%2Flocalhost%3A3000%2Ftasks';


### PR DESCRIPTION
## Summary

- Update desktop release and updater URLs after the GitHub repository rename to `desktop-tracker-suite`.
- Replace unsupported pinned `tauri-action` release inputs with supported inputs.
- Keep updater signing material in GitHub Secrets only; no private key material is committed.

## Root Cause

PR checks only run Desktop Verify, while pushes to `main` also run Desktop Release. The latest Desktop Release failure still requires a GitHub Secrets fix: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` must match the encrypted updater private key passphrase, or the private key must be replaced with an unencrypted one.

## Validation

- `pnpm nx run tools:test`
- `pnpm nx run tools:typecheck`
- `pnpm nx run tools:lint`
- `git diff --check`
- Copilot Claude implementation review: Blocked: no

## Post-Merge Note

Before expecting the release workflow to pass, set the correct `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repository secret. After the first successful release, verify the uploaded `desktop-tracker-suite-*` assets and `latest*.json` updater manifests.