### PR TITLE
chore: upgrade workspace to pnpm 11

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -233,13 +233,18 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.28.2
+          version: 11.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24.11.1
           cache: pnpm
+
+      - name: Verify Node and pnpm versions
+        run: |
+          node --version
+          pnpm --version
 
       - name: Setup GraalVM for Spring native
         if: matrix.backend == 'spring-native'
@@ -283,6 +288,9 @@ jobs:
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Assert lockfile unchanged
+        run: git diff --exit-code -- pnpm-lock.yaml
 
       - name: Prepare desktop grid variant
         run: pnpm run desktop:grid:prepare:one
@@ -356,7 +364,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.28.2
+          version: 11.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -364,8 +372,16 @@ jobs:
           node-version: 24.11.1
           cache: pnpm
 
+      - name: Verify Node and pnpm versions
+        run: |
+          node --version
+          pnpm --version
+
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Assert lockfile unchanged
+        run: git diff --exit-code -- pnpm-lock.yaml
 
       - name: Download renamed release assets and signatures
         run: |

--- a/.github/workflows/desktop-verify.yml
+++ b/.github/workflows/desktop-verify.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.28.2
+          version: 11.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -29,8 +29,16 @@ jobs:
           node-version: 24.11.1
           cache: pnpm
 
+      - name: Verify Node and pnpm versions
+        run: |
+          node --version
+          pnpm --version
+
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Assert lockfile unchanged
+        run: git diff --exit-code -- pnpm-lock.yaml
 
       - name: Run desktop tooling tests
         run: pnpm run desktop:test:tooling
@@ -73,13 +81,18 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
-          version: 10.28.2
+          version: 11.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24.11.1
           cache: pnpm
+
+      - name: Verify Node and pnpm versions
+        run: |
+          node --version
+          pnpm --version
 
       - name: Setup GraalVM for Spring native
         if: matrix.backend == 'spring-native'
@@ -123,6 +136,9 @@ jobs:
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Assert lockfile unchanged
+        run: git diff --exit-code -- pnpm-lock.yaml
 
       - name: Verify desktop grid variant
         run: pnpm run desktop:grid:verify:one

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The workspace also keeps alternative browser and backend implementations for com
 ## Prerequisites
 
 - Node.js 24+
-- pnpm
+- pnpm 11.0.1 (the workspace is pinned via `packageManager`)
 - Rust toolchain for Tauri desktop builds
 - JDK 25+ and Maven if you work on the Spring backend
 
@@ -115,16 +115,19 @@ pnpm run test-back:cov
 
 ## Troubleshooting
 
-If native SQLite dependencies are blocked during install, run:
+If native dependencies are blocked during install, run:
 
 ```bash
 pnpm approve-builds
 ```
 
+Approved and blocked dependency build scripts are recorded in
+`pnpm-workspace.yaml` under `allowBuilds`.
+
 ## Project Configuration
 
 - Monorepo: Nx
-- Package manager: pnpm
+- Package manager: pnpm 11
 - Desktop shell: Tauri
 - Web build tools: Angular CLI, Vite, Rspack
 - Backend build tools: Nx Node tooling, Maven

--- a/package.json
+++ b/package.json
@@ -205,5 +205,5 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@11.0.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,16 +2,16 @@ packages:
   - apps/*
   - libs/*
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@scarf/scarf'
-  - lmdb
-  - msgpackr-extract
-  - unrs-resolver
+nodeLinker: hoisted
 
-onlyBuiltDependencies:
-  - '@nestjs/core'
-  - '@swc/core'
-  - esbuild
-  - nx
-  - sqlite3
+allowBuilds:
+  '@nestjs/core': true
+  '@parcel/watcher': false
+  '@scarf/scarf': false
+  '@swc/core': true
+  esbuild: true
+  lmdb: false
+  msgpackr-extract: false
+  nx: true
+  sqlite3: true
+  unrs-resolver: false

--- a/tools/tauri/common.test.ts
+++ b/tools/tauri/common.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 
 import {
@@ -13,14 +16,12 @@ test('buildStagedProductionDependencyInstallArgs keeps the offline install shape
   assert.deepEqual(buildStagedProductionDependencyInstallArgs({ offline: true }), [
     'install',
     '--prod',
-    '--ignore-workspace',
     '--no-lockfile',
     '--offline',
   ]);
   assert.deepEqual(buildStagedProductionDependencyInstallArgs({ offline: false }), [
     'install',
     '--prod',
-    '--ignore-workspace',
     '--no-lockfile',
   ]);
 });
@@ -58,27 +59,29 @@ test('isPnpmOfflineMetadataMiss detects the pnpm offline metadata code', () => {
 test('installStagedProductionDependencies succeeds with the offline install first', async () => {
   const calls: CommandCall[] = [];
 
-  await installStagedProductionDependencies({
-    cwd: '/workspace/stage',
-    env: {
-      CUSTOM_ENV: 'kept',
-    },
-    isCi: true,
-    label: 'test runtime',
-    platform: 'linux',
-    run: async (...call) => {
-      calls.push(call);
-    },
-  });
+  await withStagedWorkspace(async (cwd) => {
+    await installStagedProductionDependencies({
+      cwd,
+      env: {
+        CUSTOM_ENV: 'kept',
+      },
+      isCi: true,
+      label: 'test runtime',
+      platform: 'linux',
+      run: async (...call) => {
+        calls.push(call);
+      },
+    });
 
-  assert.equal(calls.length, 1);
-  assertCommandCall(calls[0], {
-    args: buildStagedProductionDependencyInstallArgs({ offline: true }),
-    cwd: '/workspace/stage',
-    env: {
-      CUSTOM_ENV: 'kept',
-    },
-    stdio: 'pipe',
+    assert.equal(calls.length, 1);
+    assertCommandCall(calls[0], {
+      args: buildStagedProductionDependencyInstallArgs({ offline: true }),
+      cwd,
+      env: {
+        CUSTOM_ENV: 'kept',
+      },
+      stdio: 'pipe',
+    });
   });
 });
 
@@ -93,50 +96,54 @@ test('installStagedProductionDependencies falls back online in CI on offline met
     stdout: '',
   });
 
-  await installStagedProductionDependencies({
-    cwd: '/workspace/stage',
-    isCi: true,
-    label: 'test runtime',
-    platform: 'linux',
-    run: async (...call) => {
-      calls.push(call);
-      if (calls.length === 1) {
-        throw offlineError;
-      }
-    },
-  });
+  await withStagedWorkspace(async (cwd) => {
+    await installStagedProductionDependencies({
+      cwd,
+      isCi: true,
+      label: 'test runtime',
+      platform: 'linux',
+      run: async (...call) => {
+        calls.push(call);
+        if (calls.length === 1) {
+          throw offlineError;
+        }
+      },
+    });
 
-  assert.equal(calls.length, 2);
-  assertCommandCall(calls[0], {
-    args: buildStagedProductionDependencyInstallArgs({ offline: true }),
-    cwd: '/workspace/stage',
-    stdio: 'pipe',
-  });
-  assertCommandCall(calls[1], {
-    args: buildStagedProductionDependencyInstallArgs({ offline: false }),
-    cwd: '/workspace/stage',
-    stdio: 'inherit',
+    assert.equal(calls.length, 2);
+    assertCommandCall(calls[0], {
+      args: buildStagedProductionDependencyInstallArgs({ offline: true }),
+      cwd,
+      stdio: 'pipe',
+    });
+    assertCommandCall(calls[1], {
+      args: buildStagedProductionDependencyInstallArgs({ offline: false }),
+      cwd,
+      stdio: 'inherit',
+    });
   });
 });
 
 test('installStagedProductionDependencies uses the online install directly on Windows CI', async () => {
   const calls: CommandCall[] = [];
 
-  await installStagedProductionDependencies({
-    cwd: '/workspace/stage',
-    isCi: true,
-    label: 'test runtime',
-    platform: 'win32',
-    run: async (...call) => {
-      calls.push(call);
-    },
-  });
+  await withStagedWorkspace(async (cwd) => {
+    await installStagedProductionDependencies({
+      cwd,
+      isCi: true,
+      label: 'test runtime',
+      platform: 'win32',
+      run: async (...call) => {
+        calls.push(call);
+      },
+    });
 
-  assert.equal(calls.length, 1);
-  assertCommandCall(calls[0], {
-    args: buildStagedProductionDependencyInstallArgs({ offline: false }),
-    cwd: '/workspace/stage',
-    stdio: 'inherit',
+    assert.equal(calls.length, 1);
+    assertCommandCall(calls[0], {
+      args: buildStagedProductionDependencyInstallArgs({ offline: false }),
+      cwd,
+      stdio: 'inherit',
+    });
   });
 });
 
@@ -150,17 +157,19 @@ test('installStagedProductionDependencies does not fall back outside CI', async 
     stdout: '',
   });
 
-  await assert.rejects(
-    installStagedProductionDependencies({
-      cwd: '/workspace/stage',
-      isCi: false,
-      label: 'test runtime',
-      run: async () => {
-        throw offlineError;
-      },
-    }),
-    offlineError,
-  );
+  await withStagedWorkspace(async (cwd) => {
+    await assert.rejects(
+      installStagedProductionDependencies({
+        cwd,
+        isCi: false,
+        label: 'test runtime',
+        run: async () => {
+          throw offlineError;
+        },
+      }),
+      offlineError,
+    );
+  });
 });
 
 test('installStagedProductionDependencies does not fall back for other pnpm errors in CI', async () => {
@@ -174,19 +183,21 @@ test('installStagedProductionDependencies does not fall back for other pnpm erro
     stdout: '',
   });
 
-  await assert.rejects(
-    installStagedProductionDependencies({
-      cwd: '/workspace/stage',
-      isCi: true,
-      label: 'test runtime',
-      platform: 'linux',
-      run: async (...call) => {
-        calls.push(call);
-        throw otherPnpmError;
-      },
-    }),
-    otherPnpmError,
-  );
+  await withStagedWorkspace(async (cwd) => {
+    await assert.rejects(
+      installStagedProductionDependencies({
+        cwd,
+        isCi: true,
+        label: 'test runtime',
+        platform: 'linux',
+        run: async (...call) => {
+          calls.push(call);
+          throw otherPnpmError;
+        },
+      }),
+      otherPnpmError,
+    );
+  });
 
   assert.equal(calls.length, 1);
 });
@@ -195,19 +206,21 @@ test('installStagedProductionDependencies does not fall back for plain errors in
   const calls: CommandCall[] = [];
   const plainError = new Error('ERR_PNPM_NO_OFFLINE_META');
 
-  await assert.rejects(
-    installStagedProductionDependencies({
-      cwd: '/workspace/stage',
-      isCi: true,
-      label: 'test runtime',
-      platform: 'linux',
-      run: async (...call) => {
-        calls.push(call);
-        throw plainError;
-      },
-    }),
-    plainError,
-  );
+  await withStagedWorkspace(async (cwd) => {
+    await assert.rejects(
+      installStagedProductionDependencies({
+        cwd,
+        isCi: true,
+        label: 'test runtime',
+        platform: 'linux',
+        run: async (...call) => {
+          calls.push(call);
+          throw plainError;
+        },
+      }),
+      plainError,
+    );
+  });
 
   assert.equal(calls.length, 1);
 });
@@ -224,27 +237,48 @@ test('installStagedProductionDependencies surfaces online fallback failures', as
   const onlineError = new Error('registry unavailable');
   let attempts = 0;
 
-  await assert.rejects(
-    installStagedProductionDependencies({
-      cwd: '/workspace/stage',
-      isCi: true,
-      label: 'test runtime',
-      platform: 'linux',
-      run: async () => {
-        attempts += 1;
-        if (attempts === 1) {
-          throw offlineError;
-        }
+  await withStagedWorkspace(async (cwd) => {
+    await assert.rejects(
+      installStagedProductionDependencies({
+        cwd,
+        isCi: true,
+        label: 'test runtime',
+        platform: 'linux',
+        run: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw offlineError;
+          }
 
-        throw onlineError;
-      },
-    }),
-    (error) =>
-      error instanceof Error &&
-      error.message ===
-        'Online pnpm install fallback failed after an offline metadata miss for test runtime.' &&
-      error.cause === onlineError,
-  );
+          throw onlineError;
+        },
+      }),
+      (error) =>
+        error instanceof Error &&
+        error.message ===
+          'Online pnpm install fallback failed after an offline metadata miss for test runtime.' &&
+        error.cause === onlineError,
+    );
+  });
+});
+
+test('installStagedProductionDependencies rejects missing staged workspace config', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'tauri-staged-install-test-'));
+  try {
+    await assert.rejects(
+      installStagedProductionDependencies({
+        cwd,
+        isCi: true,
+        label: 'test runtime',
+        run: async () => {
+          throw new Error('install should not run');
+        },
+      }),
+      /Staged pnpm workspace config is missing/u,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
 });
 
 type CommandCall = [
@@ -252,6 +286,16 @@ type CommandCall = [
   args: string[],
   options: RunCommandOptions,
 ];
+
+async function withStagedWorkspace<T>(callback: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'tauri-staged-install-test-'));
+  try {
+    await writeFile(join(cwd, 'pnpm-workspace.yaml'), 'packages: []\n', 'utf8');
+    return await callback(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
 
 function assertCommandCall(
   call: CommandCall | undefined,

--- a/tools/tauri/common.ts
+++ b/tools/tauri/common.ts
@@ -183,7 +183,6 @@ export interface InstallStagedProductionDependenciesOptions {
 const STAGED_PRODUCTION_DEPENDENCY_INSTALL_ARGS = [
   'install',
   '--prod',
-  '--ignore-workspace',
   '--no-lockfile',
 ] as const;
 
@@ -214,10 +213,22 @@ export async function installStagedProductionDependencies({
   platform = process.platform,
   run = runSharedCommand,
 }: InstallStagedProductionDependenciesOptions): Promise<void> {
+  const workspaceConfigPath = join(cwd, 'pnpm-workspace.yaml');
+  if (!existsSync(workspaceConfigPath)) {
+    throw new Error(
+      `Staged pnpm workspace config is missing at ${workspaceConfigPath}. ` +
+        'Write pnpm-workspace.yaml before installing staged production dependencies.',
+    );
+  }
+
+  // Keep --ignore-workspace off: pnpm 11 must read the staged allowBuilds
+  // policy. Callers anchor the stage with packages: [] in pnpm-workspace.yaml.
   const installEnv = {
     ...process.env,
     ...env,
     CI: 'true',
+    // Defense in depth; the canonical staged pnpm policy lives in
+    // pnpm-workspace.yaml so build-script approvals are versioned together.
     npm_config_node_linker: 'hoisted',
     npm_config_confirm_modules_purge: 'false',
   };

--- a/tools/tauri/materialize-backend-runtime.test.ts
+++ b/tools/tauri/materialize-backend-runtime.test.ts
@@ -13,7 +13,7 @@ test('buildPackagedBackendPackageJson adds sqlite3 and preserves existing depend
         '@nestjs/common': '11.1.12',
       },
     },
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
     sqliteVersion: '5.1.7',
   });
 
@@ -22,14 +22,14 @@ test('buildPackagedBackendPackageJson adds sqlite3 and preserves existing depend
       '@nestjs/common': '11.1.12',
       sqlite3: '5.1.7',
     },
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
   });
 });
 
 test('buildPackagedBackendPackageJson handles missing dependencies object', () => {
   const packagedJson = buildPackagedBackendPackageJson({
     backendPackageJson: {},
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
     sqliteVersion: '5.1.7',
   });
 
@@ -37,14 +37,14 @@ test('buildPackagedBackendPackageJson handles missing dependencies object', () =
     dependencies: {
       sqlite3: '5.1.7',
     },
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
   });
 });
 
 test('buildPackagedBackendPackageJson trims sqlite3 versions', () => {
   const packagedJson = buildPackagedBackendPackageJson({
     backendPackageJson: {},
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
     sqliteVersion: '  5.1.7  ',
   });
 
@@ -56,7 +56,7 @@ test('buildPackagedBackendPackageJson rejects missing sqlite3 versions', () => {
     () =>
       buildPackagedBackendPackageJson({
         backendPackageJson: {},
-        packageManager: 'pnpm@10.28.2',
+        packageManager: 'pnpm@11.0.1',
         sqliteVersion: '   ',
       }),
     /sqlite3 is missing from the installed workspace dependencies\./u,

--- a/tools/tauri/materialize-backend-runtime.ts
+++ b/tools/tauri/materialize-backend-runtime.ts
@@ -25,7 +25,7 @@ import {
 } from './common.ts';
 import {
   buildPackagedNodeBackendPackageJson,
-  NODE_BACKEND_INSTALL_NPMRC,
+  NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
 } from './node-backend-packaging.ts';
 import {
   assertHostCanBuildDesktopTarget,
@@ -109,8 +109,8 @@ async function main() {
     }),
   );
   await writeTextFile(
-    join(BACKEND_RUNTIME_DIR, '.npmrc'),
-    NODE_BACKEND_INSTALL_NPMRC,
+    join(BACKEND_RUNTIME_DIR, 'pnpm-workspace.yaml'),
+    NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
   );
   await writeTextFile(join(BACKEND_RUNTIME_DIR, '.tauri-desktop-target'), `${target.profile}\n`);
   await writeTextFile(join(BACKEND_RUNTIME_DIR, '.tauri-database-name'), `${DATABASE_FILE_NAME}\n`);

--- a/tools/tauri/materialize-node-sidecar-runtime.test.ts
+++ b/tools/tauri/materialize-node-sidecar-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   buildNodeSidecarCacheManifest,
   buildDesktopRuntimeMetadata,
   type NodeSidecarCacheKeyInput,
+  getWorkspaceBinaryPath,
   resolveNodeSidecarRuntimeDefinition,
 } from './materialize-node-sidecar-runtime.ts';
 import {
@@ -75,6 +76,12 @@ test('buildNodeSidecarCacheKey is deterministic for object key order', () => {
     }),
     buildNodeSidecarCacheKey(input),
   );
+});
+
+test('buildNodeSidecarCacheKey is stable for identical inputs', () => {
+  const input = buildCacheKeyInput();
+
+  assert.equal(buildNodeSidecarCacheKey(input), buildNodeSidecarCacheKey(input));
 });
 
 test('buildNodeSidecarCacheKey changes when lockfile hash changes', () => {
@@ -149,6 +156,18 @@ test('buildNodeSidecarCacheKey changes when package environment changes', () => 
   );
 });
 
+test('buildNodeSidecarCacheKey changes when workspace config changes', () => {
+  const input = buildCacheKeyInput();
+
+  assert.notEqual(
+    buildNodeSidecarCacheKey({
+      ...input,
+      workspaceConfig: `${input.workspaceConfig}\nallowBuilds:\n  sqlite3: true\n`,
+    }),
+    buildNodeSidecarCacheKey(input),
+  );
+});
+
 test('buildNodeSidecarCacheKey changes when target or tooling inputs change', () => {
   const input = buildCacheKeyInput();
   const baselineKey = buildNodeSidecarCacheKey(input);
@@ -174,9 +193,14 @@ test('buildNodeSidecarCacheManifest records the cache key and executable path', 
     {
       cacheKey: 'cache-key',
       packagedSidecarPath: 'stage/sidecar-build/nest-backend.exe',
-      schemaVersion: 1,
+      schemaVersion: 2,
     },
   );
+});
+
+test('getWorkspaceBinaryPath resolves pkg from the workspace root', () => {
+  assert.match(getWorkspaceBinaryPath('pkg', 'win32'), /node_modules[\\\/]\.bin[\\\/]pkg\.cmd$/u);
+  assert.match(getWorkspaceBinaryPath('pkg', 'linux'), /node_modules[\\\/]\.bin[\\\/]pkg$/u);
 });
 
 test('buildNodeSidecarPackageJson adds pkg metadata and sqlite3 to the runtime package', () => {
@@ -227,10 +251,13 @@ test('buildNodeSidecarPkgConfig includes json assets and native addons', () => {
 });
 
 test('NODE_BACKEND_INSTALL_WORKSPACE_CONFIG uses pnpm 11 workspace settings', () => {
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /packages: \[\]/u);
   assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /nodeLinker: hoisted/u);
   assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /allowBuilds:/u);
   assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /'@nestjs\/core': true/u);
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /'@scarf\/scarf': false/u);
   assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /sqlite3: true/u);
+  assert.doesNotMatch(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /'\s+@/u);
   assert.doesNotMatch(
     NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
     /node-linker|only-built-dependencies|onlyBuiltDependencies|ignoredBuiltDependencies/u,
@@ -267,5 +294,6 @@ function buildCacheKeyInput(): NodeSidecarCacheKeyInput {
     profile: 'windows-x64',
     rustTarget: 'x86_64-pc-windows-msvc',
     sidecarName: 'nest-backend',
+    workspaceConfig: NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
   };
 }

--- a/tools/tauri/materialize-node-sidecar-runtime.test.ts
+++ b/tools/tauri/materialize-node-sidecar-runtime.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildNodeSidecarPackageJson,
   buildNodeSidecarPkgConfig,
+  NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
 } from './node-backend-packaging.ts';
 
 test('buildDesktopRuntimeMetadata records the Nest sidecar manifest fields', () => {
@@ -187,7 +188,7 @@ test('buildNodeSidecarPackageJson adds pkg metadata and sqlite3 to the runtime p
       main: 'main.js',
       version: '0.0.1',
     },
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
     sidecarName: 'nest-backend',
     sqliteVersion: '5.1.7',
   });
@@ -195,7 +196,7 @@ test('buildNodeSidecarPackageJson adds pkg metadata and sqlite3 to the runtime p
   assert.equal(packagedJson.bin, 'main.js');
   assert.equal(packagedJson.name, 'nest-backend');
   assert.equal(packagedJson.private, true);
-  assert.equal(packagedJson.packageManager, 'pnpm@10.28.2');
+  assert.equal(packagedJson.packageManager, 'pnpm@11.0.1');
   assert.deepEqual(packagedJson.dependencies, {
     sqlite3: '5.1.7',
     typeorm: '0.3.28',
@@ -225,6 +226,17 @@ test('buildNodeSidecarPkgConfig includes json assets and native addons', () => {
   });
 });
 
+test('NODE_BACKEND_INSTALL_WORKSPACE_CONFIG uses pnpm 11 workspace settings', () => {
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /nodeLinker: hoisted/u);
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /allowBuilds:/u);
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /'@nestjs\/core': true/u);
+  assert.match(NODE_BACKEND_INSTALL_WORKSPACE_CONFIG, /sqlite3: true/u);
+  assert.doesNotMatch(
+    NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
+    /node-linker|only-built-dependencies|onlyBuiltDependencies|ignoredBuiltDependencies/u,
+  );
+});
+
 function buildCacheKeyInput(): NodeSidecarCacheKeyInput {
   return {
     backendDistHash: 'backend-dist-hash',
@@ -235,7 +247,7 @@ function buildCacheKeyInput(): NodeSidecarCacheKeyInput {
       npm_config_confirm_modules_purge: 'false',
       npm_config_node_linker: 'hoisted',
     },
-    packageManager: 'pnpm@10.28.2',
+    packageManager: 'pnpm@11.0.1',
     packagedPackageJson: {
       bin: 'main.js',
       dependencies: {

--- a/tools/tauri/materialize-node-sidecar-runtime.ts
+++ b/tools/tauri/materialize-node-sidecar-runtime.ts
@@ -10,7 +10,6 @@ import {
   NEST_BACKEND_SIDECAR_NAME,
   NEST_DIST_DIR,
   NODE_SIDECAR_STAGE_ROOT,
-  PNPM_COMMAND,
   TAURI_BINARIES_DIR,
   TAURI_EXPRESS_SIDECAR_DIST_ROOT,
   TAURI_EXPRESS_SIDECAR_METADATA_DIR,
@@ -87,9 +86,10 @@ export type NodeSidecarCacheKeyInput = {
   profile: string;
   rustTarget: string;
   sidecarName: string;
+  workspaceConfig: string;
 };
 
-const NODE_SIDECAR_CACHE_SCHEMA_VERSION = 1;
+const NODE_SIDECAR_CACHE_SCHEMA_VERSION = 2;
 const NODE_SIDECAR_CACHE_MANIFEST_NAME = 'materialize-cache.json';
 
 const NODE_SIDECAR_RUNTIME_DEFINITIONS: Record<
@@ -150,6 +150,18 @@ export function buildNodeSidecarCacheManifest(input: {
   };
 }
 
+export function getWorkspaceBinaryPath(
+  binaryName: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return join(
+    WORKSPACE_ROOT,
+    'node_modules',
+    '.bin',
+    platform === 'win32' ? `${binaryName}.cmd` : binaryName,
+  );
+}
+
 async function main() {
   const runtimeMode = parseRuntimeMode(process.argv[2]);
   const runtimeDefinition = resolveNodeSidecarRuntimeDefinition(runtimeMode);
@@ -201,6 +213,7 @@ async function main() {
     profile: target.profile,
     rustTarget: target.rustTarget,
     sidecarName: runtimeDefinition.sidecarName,
+    workspaceConfig: NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
   });
 
   const cachedSidecar = await resolveCachedSidecar({
@@ -257,9 +270,14 @@ async function main() {
 
   await ensureCleanDir(sidecarBuildDir);
   logStep(`Packaging the ${runtimeDefinition.label} backend into a self-contained sidecar executable`);
+  const pkgCommand = getWorkspaceBinaryPath('pkg');
+  if (!(await fileExists(pkgCommand))) {
+    throw new Error(`Workspace pkg binary is missing at ${pkgCommand}. Run pnpm install first.`);
+  }
+
   await runCommand(
-    PNPM_COMMAND,
-    ['exec', 'pkg', '.', '--targets', 'host', '--fallback-to-source', '--output', outputBasePath],
+    pkgCommand,
+    ['.', '--targets', 'host', '--fallback-to-source', '--output', outputBasePath],
     {
       cwd: stageRoot,
       env: {

--- a/tools/tauri/materialize-node-sidecar-runtime.ts
+++ b/tools/tauri/materialize-node-sidecar-runtime.ts
@@ -33,7 +33,7 @@ import {
 } from './common.ts';
 import {
   buildNodeSidecarPackageJson,
-  NODE_BACKEND_INSTALL_NPMRC,
+  NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
 } from './node-backend-packaging.ts';
 import {
   assertHostCanBuildDesktopTarget,
@@ -228,7 +228,10 @@ async function main() {
     join(stageRoot, 'package.json'),
     packagedPackageJson,
   );
-  await writeTextFile(join(stageRoot, '.npmrc'), NODE_BACKEND_INSTALL_NPMRC);
+  await writeTextFile(
+    join(stageRoot, 'pnpm-workspace.yaml'),
+    NODE_BACKEND_INSTALL_WORKSPACE_CONFIG,
+  );
 
   logStep(
     `Installing production dependencies for the packaged ${runtimeDefinition.label} sidecar (${target.profile})`,

--- a/tools/tauri/node-backend-packaging.ts
+++ b/tools/tauri/node-backend-packaging.ts
@@ -14,11 +14,13 @@ export type NodeSidecarPkgConfig = {
   ignore?: string[];
 };
 
-export const NODE_BACKEND_INSTALL_NPMRC =
+export const NODE_BACKEND_INSTALL_WORKSPACE_CONFIG =
   [
-    'node-linker=hoisted',
-    'only-built-dependencies[]=@nestjs/core',
-    'only-built-dependencies[]=sqlite3',
+    'nodeLinker: hoisted',
+    '',
+    'allowBuilds:',
+    "  '@nestjs/core': true",
+    '  sqlite3: true',
   ].join('\n') + '\n';
 
 export function buildPackagedNodeBackendPackageJson(input: {

--- a/tools/tauri/node-backend-packaging.ts
+++ b/tools/tauri/node-backend-packaging.ts
@@ -16,10 +16,13 @@ export type NodeSidecarPkgConfig = {
 
 export const NODE_BACKEND_INSTALL_WORKSPACE_CONFIG =
   [
+    'packages: []',
+    '',
     'nodeLinker: hoisted',
     '',
     'allowBuilds:',
     "  '@nestjs/core': true",
+    "  '@scarf/scarf': false",
     '  sqlite3: true',
   ].join('\n') + '\n';
 


### PR DESCRIPTION
## Summary
- upgrade the workspace package manager pin to pnpm 11.0.1
- migrate pnpm 11 settings into pnpm-workspace.yaml with allowBuilds and nodeLinker
- update GitHub Actions pnpm setup pins and add install preflight/lockfile guard steps
- update Tauri staged runtime packaging to write pnpm-workspace.yaml instead of legacy .npmrc config

## Verification
- CI=true pnpm install --frozen-lockfile
- git diff --exit-code -- pnpm-lock.yaml
- pnpm nx run tools:test --outputStyle=static
- pnpm nx run tools:typecheck --outputStyle=static
- pnpm nx run-many -t typecheck --outputStyle=static
- pnpm nx run-many -t test --outputStyle=static
- pnpm nx run-many -t build -p ng-tracker react-tracker vue-tracker nest-backend express-backend --outputStyle=static
- git diff --check

## Notes
- pnpm-lock.yaml is unchanged.
- The repo now expects pnpm 11.0.1 via packageManager.