### PR TITLE
refactor: extract shared task-domain lib and unify Nx project configs

### DIFF
--- a/apps/express-backend/src/app/core/database/database.config.ts
+++ b/apps/express-backend/src/app/core/database/database.config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { cwd } from 'node:process';
 import { DataSourceOptions } from 'typeorm';
-import { Task } from '../../feature/task/task.entity';
+import { TaskEntity as Task } from '@task-domain';
 
 const DATABASE_NAME = 'database.sqlite3';
 

--- a/apps/express-backend/src/app/feature/task/task.service.spec.ts
+++ b/apps/express-backend/src/app/feature/task/task.service.spec.ts
@@ -3,26 +3,28 @@ import 'reflect-metadata';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Like } from 'typeorm';
 
-const { MockTaskEntity, mockGetRepository, mockTaskRepository } = vi.hoisted(() => {
-  class TaskEntityMock {}
-  const repository = {
-    create: vi.fn(),
-    save: vi.fn(),
-    findAndCount: vi.fn(),
-    findOne: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-  };
+const { MockTaskEntity, mockGetRepository, mockTaskRepository } = vi.hoisted(
+  () => {
+    class TaskEntityMock {}
+    const repository = {
+      create: vi.fn(),
+      save: vi.fn(),
+      findAndCount: vi.fn(),
+      findOne: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
 
-  return {
-    MockTaskEntity: TaskEntityMock,
-    mockGetRepository: vi.fn(() => repository),
-    mockTaskRepository: repository,
-  };
-});
+    return {
+      MockTaskEntity: TaskEntityMock,
+      mockGetRepository: vi.fn(() => repository),
+      mockTaskRepository: repository,
+    };
+  },
+);
 
-vi.mock('./task.entity', () => ({
-  Task: MockTaskEntity,
+vi.mock('@task-domain', () => ({
+  TaskEntity: MockTaskEntity,
 }));
 
 vi.mock('../../core/database/database', () => ({
@@ -31,7 +33,7 @@ vi.mock('../../core/database/database', () => ({
   },
 }));
 
-import { Task } from './task.entity';
+import { TaskEntity as Task } from '@task-domain';
 import { TaskService } from './task.service';
 
 describe('TaskService', () => {
@@ -152,7 +154,9 @@ describe('TaskService', () => {
   });
 
   it('surfaces repository errors during findAll', async () => {
-    mockTaskRepository.findAndCount.mockRejectedValue(new Error('query failed'));
+    mockTaskRepository.findAndCount.mockRejectedValue(
+      new Error('query failed'),
+    );
 
     await expect(service.findAll()).rejects.toThrow('query failed');
   });

--- a/apps/express-backend/src/app/feature/task/task.service.ts
+++ b/apps/express-backend/src/app/feature/task/task.service.ts
@@ -1,5 +1,5 @@
 import { Repository, Like } from 'typeorm';
-import { Task } from './task.entity';
+import { TaskEntity as Task } from '@task-domain';
 import {
   CreateTaskDto,
   UpdateTaskDto,

--- a/apps/nest-backend/src/app/feature/task/task.module.ts
+++ b/apps/nest-backend/src/app/feature/task/task.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TaskService } from './task.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Task } from './entities/task.entity';
+import { TaskEntity as Task } from '@task-domain';
 import { TaskController } from './task.controller';
 
 @Module({

--- a/apps/nest-backend/src/app/feature/task/task.service.spec.ts
+++ b/apps/nest-backend/src/app/feature/task/task.service.spec.ts
@@ -16,11 +16,11 @@ const { MockTaskEntity } = vi.hoisted(() => {
   };
 });
 
-vi.mock('./entities/task.entity', () => ({
-  Task: MockTaskEntity,
+vi.mock('@task-domain', () => ({
+  TaskEntity: MockTaskEntity,
 }));
 
-import { Task } from './entities/task.entity';
+import { TaskEntity as Task } from '@task-domain';
 
 describe('TaskService', () => {
   let service: TaskService;
@@ -97,7 +97,7 @@ describe('TaskService', () => {
         order: {
           createdAt: 'DESC',
         },
-      })
+      }),
     );
     expect(result).toEqual({
       data: expectedTasks,
@@ -126,7 +126,7 @@ describe('TaskService', () => {
         order: {
           createdAt: 'DESC',
         },
-      })
+      }),
     );
     expect(result).toEqual({
       data: [],
@@ -137,7 +137,9 @@ describe('TaskService', () => {
     });
   });
   it('should surface repository errors during findAll', async () => {
-    mockTaskRepository.findAndCount.mockRejectedValue(new Error('query failed'));
+    mockTaskRepository.findAndCount.mockRejectedValue(
+      new Error('query failed'),
+    );
 
     await expect(service.findAll()).rejects.toThrow('query failed');
   });
@@ -160,7 +162,7 @@ describe('TaskService', () => {
         order: {
           createdAt: 'DESC',
         },
-      })
+      }),
     );
     expect(result).toEqual({
       data: expectedTasks,
@@ -245,7 +247,7 @@ describe('TaskService', () => {
     mockTaskRepository.update.mockRejectedValue(new Error('update failed'));
 
     await expect(service.update('1', updateTaskDto)).rejects.toThrow(
-      'update failed'
+      'update failed',
     );
   });
   it('should surface repository errors when reloading an updated task', async () => {
@@ -259,7 +261,7 @@ describe('TaskService', () => {
     mockTaskRepository.findOne.mockRejectedValue(new Error('reload failed'));
 
     await expect(service.update('1', updateTaskDto)).rejects.toThrow(
-      'reload failed'
+      'reload failed',
     );
   });
   it('should remove a task by id', async () => {
@@ -323,7 +325,7 @@ describe('TaskService', () => {
     mockTaskRepository.delete.mockRejectedValue(new Error('delete failed'));
 
     await expect(service.removeByName('missing')).rejects.toThrow(
-      'delete failed'
+      'delete failed',
     );
   });
 });

--- a/apps/nest-backend/src/app/feature/task/task.service.ts
+++ b/apps/nest-backend/src/app/feature/task/task.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
-import { Task } from './entities/task.entity';
+import { TaskEntity as Task } from '@task-domain';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Like } from 'typeorm';
 import {
@@ -13,7 +13,7 @@ import {
 export class TaskService {
   constructor(
     @InjectRepository(Task)
-    private readonly taskRepository: Repository<Task>
+    private readonly taskRepository: Repository<Task>,
   ) {}
 
   async create(createTaskDto: CreateTaskDto): Promise<Task> {

--- a/apps/ng-tracker/src/app/modules/add-task/components/task-form.component.ts
+++ b/apps/ng-tracker/src/app/modules/add-task/components/task-form.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Task } from '../../../interfaces/task.interface';
+import { Task } from '@task-domain';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TaskService } from '../../../shared/services/task.service';
@@ -120,7 +120,7 @@ export class TaskFormComponent {
   constructor(
     private readonly fb: FormBuilder,
     private readonly router: Router,
-    private readonly taskService: TaskService
+    private readonly taskService: TaskService,
   ) {}
 
   cancelAddTask() {
@@ -136,7 +136,7 @@ export class TaskFormComponent {
     const newTask: Task = {
       id: uuidv4(),
       text: this.taskForm.value.text,
-      day: this.taskForm.value.date,
+      day: this.taskForm.value.date?.toISOString() ?? '',
       reminder: this.taskForm.value.reminder || false,
     };
 
@@ -145,7 +145,7 @@ export class TaskFormComponent {
       .pipe(
         tap(() => {
           this.router.navigate(['/']);
-        })
+        }),
       )
       .subscribe();
   }

--- a/apps/ng-tracker/src/app/modules/tracker/components/task-item.component.ts
+++ b/apps/ng-tracker/src/app/modules/tracker/components/task-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, input, output, inject } from '@angular/core';
-import { Task } from '../../../interfaces/task.interface';
+import { Task } from '@task-domain';
 import { DatePipe, NgClass } from '@angular/common';
 import { TaskService } from '../../../shared/services/task.service';
 import { take } from 'rxjs';
@@ -19,7 +19,7 @@ import { ConfirmService } from '../../../shared/services/confirm.service';
         'hover:shadow-xl': true,
         'transition-all': true,
         'duration-300': true,
-        'cursor-pointer': true
+        'cursor-pointer': true,
       }"
       [pTooltip]="'Tip: Double-click to toggle reminder'"
       tooltipPosition="top"
@@ -37,15 +37,16 @@ import { ConfirmService } from '../../../shared/services/confirm.service';
             class="text-sm text-gray-600 dark:text-slate-300 flex items-center gap-2"
           >
             <i class="pi pi-calendar text-blue-600 dark:text-blue-400"></i>
-            {{ task().day | date : 'medium' }}
+            {{ task().day | date: 'medium' }}
           </p>
           @if (task().reminder) {
-          <div class="mt-2 flex items-center gap-2">
-            <i class="pi pi-bell text-amber-500"></i>
-            <span class="text-xs text-amber-600 dark:text-amber-400 font-medium"
-              >Reminder Set</span
-            >
-          </div>
+            <div class="mt-2 flex items-center gap-2">
+              <i class="pi pi-bell text-amber-500"></i>
+              <span
+                class="text-xs text-amber-600 dark:text-amber-400 font-medium"
+                >Reminder Set</span
+              >
+            </div>
           }
         </div>
         <p-button

--- a/apps/ng-tracker/src/app/modules/tracker/components/tasks.component.ts
+++ b/apps/ng-tracker/src/app/modules/tracker/components/tasks.component.ts
@@ -1,6 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { TaskService } from '../../../shared/services/task.service';
-import { Task } from '../../../interfaces/task.interface';
+import { Task } from '@task-domain';
 import { formatDatabaseError } from '../../../shared/utils/error-formatter';
 import { MessageService } from 'primeng/api';
 import { TaskItemComponent } from './task-item.component';
@@ -53,45 +53,52 @@ import { debounceTime, Subject } from 'rxjs';
       </div>
 
       @if (loading()) {
-      <div class="flex justify-center items-center py-12">
+        <div class="flex justify-center items-center py-12">
+          <div
+            class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 dark:border-blue-400"
+          ></div>
+        </div>
+      }
+      @if (error()) {
         <div
-          class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 dark:border-blue-400"
-        ></div>
-      </div>
-      } @if (error()) {
-      <div
-        class="bg-red-50 dark:bg-red-950 border border-red-300 dark:border-red-700 text-red-800 dark:text-red-300 px-4 py-3 rounded-lg mb-4"
-        role="alert"
-      >
-        <strong class="font-bold">Error:</strong>
-        <span class="block sm:inline ml-2">{{ error() }}</span>
-      </div>
-      } @if (!loading() && !error() && tasks().length === 0) {
-      <div class="text-center py-12">
-        <p class="text-gray-500 dark:text-slate-400 text-lg">
-          No tasks found. {{ searchQuery ? 'Try a different search.' : 'Add one to get started!' }}
-        </p>
-      </div>
+          class="bg-red-50 dark:bg-red-950 border border-red-300 dark:border-red-700 text-red-800 dark:text-red-300 px-4 py-3 rounded-lg mb-4"
+          role="alert"
+        >
+          <strong class="font-bold">Error:</strong>
+          <span class="block sm:inline ml-2">{{ error() }}</span>
+        </div>
+      }
+      @if (!loading() && !error() && tasks().length === 0) {
+        <div class="text-center py-12">
+          <p class="text-gray-500 dark:text-slate-400 text-lg">
+            No tasks found.
+            {{
+              searchQuery
+                ? 'Try a different search.'
+                : 'Add one to get started!'
+            }}
+          </p>
+        </div>
       }
       <div class="grid gap-4 md:grid-cols-1 lg:grid-cols-2">
         @for (task of tasks(); track task.id) {
-        <app-task-item
-          [task]="task"
-          (taskChanged)="refreshTasks()"
-        ></app-task-item>
+          <app-task-item
+            [task]="task"
+            (taskChanged)="refreshTasks()"
+          ></app-task-item>
         }
       </div>
 
       @if (!loading() && tasks().length > 0) {
-      <div class="mt-6">
-        <p-paginator
-          [first]="first()"
-          [rows]="rows()"
-          [totalRecords]="totalRecords()"
-          [rowsPerPageOptions]="[5, 10, 20, 50]"
-          (onPageChange)="onPageChange($event)"
-        ></p-paginator>
-      </div>
+        <div class="mt-6">
+          <p-paginator
+            [first]="first()"
+            [rows]="rows()"
+            [totalRecords]="totalRecords()"
+            [rowsPerPageOptions]="[5, 10, 20, 50]"
+            (onPageChange)="onPageChange($event)"
+          ></p-paginator>
+        </div>
       }
     </div>
   `,
@@ -101,20 +108,20 @@ export class TasksComponent {
   tasks = signal<Task[]>([]);
   loading = signal(false);
   error = signal<string | null>(null);
-  
+
   // Pagination state
   first = signal(0); // First record index
   rows = signal(10); // Records per page
   totalRecords = signal(0);
   currentPage = signal(1);
-  
+
   // Search state
   searchQuery = '';
   private readonly searchSubject = new Subject<string>();
 
   constructor(
     private taskService: TaskService,
-    private messageService: MessageService
+    private messageService: MessageService,
   ) {
     // Set up debounced search
     this.searchSubject.pipe(debounceTime(300)).subscribe((query) => {

--- a/apps/ng-tracker/src/app/shared/services/task.service.ts
+++ b/apps/ng-tracker/src/app/shared/services/task.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { catchError, Observable } from 'rxjs';
-import { Task } from '../../interfaces/task.interface';
+import { Task, PaginatedResponse, PaginationQuery } from '@task-domain';
 import { environment } from '../../../environments/environment';
 import { formatDatabaseError } from '../utils/error-formatter';
 
@@ -22,20 +22,6 @@ function resolveTaskApiUrl(): string {
 
 const TASK_API_URL = resolveTaskApiUrl();
 
-export interface PaginatedResponse<T> {
-  data: T[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
-
-export interface TaskQueryParams {
-  page?: number;
-  limit?: number;
-  search?: string;
-}
-
 const httpOptions = {
   headers: new HttpHeaders({
     'Content-Type': 'application/json',
@@ -48,9 +34,9 @@ const httpOptions = {
 export class TaskService {
   constructor(private readonly http: HttpClient) {}
 
-  getTasks(params?: TaskQueryParams): Observable<PaginatedResponse<Task>> {
+  getTasks(params?: PaginationQuery): Observable<PaginatedResponse<Task>> {
     let httpParams = new HttpParams();
-    
+
     if (params?.page) {
       httpParams = httpParams.set('page', params.page.toString());
     }
@@ -68,7 +54,7 @@ export class TaskService {
           console.error('Task API Error:', formatDatabaseError(error));
           console.error('Full error details:', error);
           throw error;
-        })
+        }),
       );
   }
 
@@ -78,7 +64,7 @@ export class TaskService {
         console.error('Delete Task Error:', formatDatabaseError(error));
         console.error('Full error details:', error);
         return [];
-      })
+      }),
     );
   }
 
@@ -90,7 +76,7 @@ export class TaskService {
           console.error('Update Task Error:', formatDatabaseError(error));
           console.error('Full error details:', error);
           return [];
-        })
+        }),
       );
   }
 
@@ -102,7 +88,7 @@ export class TaskService {
           console.error('Add Task Error:', formatDatabaseError(error));
           console.error('Full error details:', error);
           return [];
-        })
+        }),
       );
   }
 }

--- a/apps/react-tracker/project.json
+++ b/apps/react-tracker/project.json
@@ -5,5 +5,49 @@
   "projectType": "application",
   "tags": [],
   "// targets": "to see all targets run: nx show project react-tracker --web",
-  "targets": {}
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "outputPath": "dist/react-tracker"
+      },
+      "configurations": {
+        "development": {
+          "mode": "development"
+        },
+        "production": {
+          "mode": "production"
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nx/vite:dev-server",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "react-tracker:build"
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "react-tracker:build:development",
+          "hmr": true
+        },
+        "production": {
+          "buildTarget": "react-tracker:build:production",
+          "hmr": false
+        }
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../coverage/react-tracker"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
 }

--- a/apps/react-tracker/src/components/tasks/TaskForm.tsx
+++ b/apps/react-tracker/src/components/tasks/TaskForm.tsx
@@ -5,7 +5,7 @@ import { Button } from 'primereact/button';
 import { Calendar } from 'primereact/calendar';
 import { Checkbox } from 'primereact/checkbox';
 import { taskService } from '../../services/task.service';
-import type { Task } from '../../interfaces/task.interface';
+import type { Task } from '@task-domain';
 
 export const TaskForm = () => {
   const navigate = useNavigate();
@@ -29,16 +29,12 @@ export const TaskForm = () => {
     const newTask: Task = {
       id: uuidv4(),
       text: taskText,
-      day: taskDate,
+      day: taskDate.toISOString(),
       reminder: taskReminder,
     };
 
     try {
-      const taskPayload = {
-        ...newTask,
-        day: newTask.day instanceof Date ? newTask.day.toISOString() : newTask.day,
-      };
-      await taskService.addTask(taskPayload as Task);
+      await taskService.addTask(newTask);
       navigate('/');
     } catch (error) {
       console.error('Failed to add task:', error);

--- a/apps/react-tracker/src/components/tasks/TaskItem.tsx
+++ b/apps/react-tracker/src/components/tasks/TaskItem.tsx
@@ -3,7 +3,7 @@ import { Button } from 'primereact/button';
 import { Tooltip } from 'primereact/tooltip';
 import { taskService } from '../../services/task.service';
 import { useConfirm } from '../../hooks/useConfirm';
-import type { Task } from '../../interfaces/task.interface';
+import type { Task } from '@task-domain';
 
 interface TaskItemProps {
   task: Task;
@@ -39,7 +39,7 @@ export const TaskItem = ({ task, onTaskChanged }: TaskItemProps) => {
     }
   };
 
-  const formatDate = (date: Date | null) => {
+  const formatDate = (date: string) => {
     if (!date) return '';
     return new Date(date).toLocaleString('en-US', {
       year: 'numeric',

--- a/apps/react-tracker/src/components/tasks/TasksComponent.tsx
+++ b/apps/react-tracker/src/components/tasks/TasksComponent.tsx
@@ -6,7 +6,7 @@ import { Button } from 'primereact/button';
 import { IconField } from 'primereact/iconfield';
 import { InputIcon } from 'primereact/inputicon';
 import { Paginator, PaginatorPageChangeEvent } from 'primereact/paginator';
-import type { Task } from '../../interfaces/task.interface';
+import type { Task } from '@task-domain';
 
 export const TasksComponent = () => {
   const [tasks, setTasks] = useState<Task[]>([]);

--- a/apps/react-tracker/src/services/task.service.ts
+++ b/apps/react-tracker/src/services/task.service.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
-import type {
-  Task,
-  PaginatedResponse,
-  TaskQueryParams,
-} from '../interfaces/task.interface';
+import type { Task, PaginatedResponse, PaginationQuery } from '@task-domain';
 import { environment } from '../config/environment';
 
 const viteTaskApiUrl = import.meta.env.VITE_TASK_API_URL as string | undefined;
@@ -23,7 +19,7 @@ const http = axios.create({
 });
 
 export const taskService = {
-  async getTasks(params?: TaskQueryParams): Promise<PaginatedResponse<Task>> {
+  async getTasks(params?: PaginationQuery): Promise<PaginatedResponse<Task>> {
     try {
       const response = await http.get<PaginatedResponse<Task>>('', { params });
       return response.data;

--- a/apps/vue-tracker/project.json
+++ b/apps/vue-tracker/project.json
@@ -4,5 +4,49 @@
   "projectType": "application",
   "sourceRoot": "apps/vue-tracker/src",
   "// targets": "to see all targets run: nx show project vue-tracker --web",
-  "targets": {}
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "outputPath": "dist/vue-tracker"
+      },
+      "configurations": {
+        "development": {
+          "mode": "development"
+        },
+        "production": {
+          "mode": "production"
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nx/vite:dev-server",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "vue-tracker:build"
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "vue-tracker:build:development",
+          "hmr": true
+        },
+        "production": {
+          "buildTarget": "vue-tracker:build:production",
+          "hmr": false
+        }
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../coverage/vue-tracker"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
 }

--- a/apps/vue-tracker/src/components/tasks/TaskForm.vue
+++ b/apps/vue-tracker/src/components/tasks/TaskForm.vue
@@ -7,7 +7,7 @@ import InputText from 'primevue/inputtext';
 import DatePicker from 'primevue/datepicker';
 import Checkbox from 'primevue/checkbox';
 import { taskService } from '../../services/task.service';
-import type { CreateTaskDto } from '../../interfaces/task.interface';
+import type { CreateTaskDto } from '@task-domain';
 
 const router = useRouter();
 

--- a/apps/vue-tracker/src/components/tasks/TaskItem.vue
+++ b/apps/vue-tracker/src/components/tasks/TaskItem.vue
@@ -4,7 +4,7 @@ import Card from 'primevue/card';
 import Button from 'primevue/button';
 import { taskService } from '../../services/task.service';
 import { useConfirmService } from '../../composables/useConfirm';
-import type { Task } from '../../interfaces/task.interface';
+import type { Task } from '@task-domain';
 
 const props = defineProps<{
   task: Task;
@@ -53,7 +53,7 @@ const toggleReminder = async () => {
   }
 };
 
-const formatDate = (date: Date | null) => {
+const formatDate = (date: string) => {
   if (!date) return '';
   return new Date(date).toLocaleString('en-US', {
     year: 'numeric',

--- a/apps/vue-tracker/src/components/tasks/TasksComponent.vue
+++ b/apps/vue-tracker/src/components/tasks/TasksComponent.vue
@@ -8,7 +8,7 @@ import Button from 'primevue/button';
 import IconField from 'primevue/iconfield';
 import InputIcon from 'primevue/inputicon';
 import Paginator from 'primevue/paginator';
-import type { Task } from '../../interfaces/task.interface';
+import type { Task } from '@task-domain';
 import type { PageState } from 'primevue/paginator';
 
 const tasks = ref<Task[]>([]);

--- a/apps/vue-tracker/src/services/task.service.ts
+++ b/apps/vue-tracker/src/services/task.service.ts
@@ -3,8 +3,8 @@ import type {
   Task,
   CreateTaskDto,
   PaginatedResponse,
-  TaskQueryParams,
-} from '../interfaces/task.interface';
+  PaginationQuery,
+} from '@task-domain';
 import { environment } from '../config/environment';
 
 const http = axios.create({
@@ -30,7 +30,7 @@ http.interceptors.request.use(
   (error) => {
     console.error('Request interceptor error:', error);
     return Promise.reject(error);
-  }
+  },
 );
 
 // Add response interceptor for debugging
@@ -55,11 +55,11 @@ http.interceptors.response.use(
       },
     });
     return Promise.reject(error);
-  }
+  },
 );
 
 export const taskService = {
-  async getTasks(params?: TaskQueryParams): Promise<PaginatedResponse<Task>> {
+  async getTasks(params?: PaginationQuery): Promise<PaginatedResponse<Task>> {
     try {
       const response = await http.get<PaginatedResponse<Task>>('', { params });
       return response.data;

--- a/libs/task-domain/project.json
+++ b/libs/task-domain/project.json
@@ -1,0 +1,12 @@
+{
+  "name": "task-domain",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/task-domain/src",
+  "projectType": "library",
+  "tags": ["domain", "shared"],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/task-domain/src/index.ts
+++ b/libs/task-domain/src/index.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// Task Domain – shared types, interfaces, and entity for the task tracker
+// ---------------------------------------------------------------------------
+
+// Pure data interfaces (no framework dependencies)
+export type {
+  Task,
+  CreateTaskDto,
+  PaginatedResponse,
+  PaginationQuery,
+} from './lib/task.interface';
+
+// TypeORM entity (used by nest-backend and express-backend)
+export { Task as TaskEntity } from './lib/task.entity';

--- a/libs/task-domain/src/lib/task.entity.ts
+++ b/libs/task-domain/src/lib/task.entity.ts
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// TypeORM entity – used by nest-backend AND express-backend.
+// Both backends previously had identical copies of this class.
+// ---------------------------------------------------------------------------
+
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('tasks')
+export class Task {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  text!: string;
+
+  @Column()
+  day!: string;
+
+  @Column()
+  reminder!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/libs/task-domain/src/lib/task.interface.ts
+++ b/libs/task-domain/src/lib/task.interface.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Pure data shapes – no runtime framework dependencies.
+// Suitable for both frontend (Angular, React, Vue) and backend consumption.
+// ---------------------------------------------------------------------------
+
+/** Core task data model */
+export interface Task {
+  id: string;
+  text: string;
+  day: string;
+  reminder: boolean;
+}
+
+/** Payload for creating a new task */
+export interface CreateTaskDto {
+  id: string;
+  text: string;
+  day: string;
+  reminder: boolean;
+}
+
+/** Standard paginated API response envelope */
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+/** Query parameters for paginated task listing */
+export interface PaginationQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+}

--- a/libs/task-domain/tsconfig.json
+++ b/libs/task-domain/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/task-domain/tsconfig.lib.json
+++ b/libs/task-domain/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,9 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@task-domain": ["libs/task-domain/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary

Extracts shared task-domain primitives into `libs/task-domain` and migrates the Angular, React, Vue, NestJS, and Express task flows to consume the same task types and TypeORM entity. This also fills in the missing Nx Vite targets for the React and Vue tracker apps.

## Changes

- Added `libs/task-domain` with shared `Task`, `CreateTaskDto`, `PaginatedResponse<T>`, `PaginationQuery`, and the shared TypeORM `TaskEntity`.
- Replaced duplicated frontend task interfaces, paginated response shapes, and backend task entities with imports from `@task-domain`.
- Normalized `Task.day` to the API wire format (`string`) and updated form submissions to serialize selected dates with `toISOString()` before create calls.
- Added `build`, `serve`, `test`, and `lint` Nx targets for `react-tracker` and `vue-tracker` using the Vite executors.
- Updated affected NestJS and Express unit tests to mock the shared domain entity import.

## Review Focus

- Confirm the `@task-domain` path mapping and imports work across all five TypeScript apps.
- Check the date-handling path after `day` moved from mixed `Date | string` usage to a string wire format.
- Review the new React/Vue `project.json` targets for parity with the workspace's Vite conventions.

## Verification

Recorded in the PR commit/body before this description cleanup:

- `ng-tracker` build passes.
- `react-tracker` build passes.
- `vue-tracker` build passes.
- `nest-backend` build passes; `nest-backend` tests pass (24 tests).
- `express-backend` build passes; `express-backend` tests pass (24 tests).

GitHub Actions checks remain the source of truth for the full OS/app/backend matrix.